### PR TITLE
Add flushSync

### DIFF
--- a/src/React/Basic/DOM.js
+++ b/src/React/Basic/DOM.js
@@ -19,3 +19,7 @@ export function unmount(node) {
 export function createPortal(jsx) {
   return (node) => ReactDOM.createPortal(jsx, node);
 }
+
+export function flushSync(callback) {
+  return () => ReactDOM.flushSync(callback);
+}

--- a/src/React/Basic/DOM.purs
+++ b/src/React/Basic/DOM.purs
@@ -13,6 +13,7 @@ module React.Basic.DOM
   , unmount
   , createPortal
   , text
+  , flushSync
   , module Generated
   ) where
 
@@ -101,3 +102,14 @@ foreign import createPortal :: JSX -> Element -> JSX
 -- | Create a text node.
 text :: String -> JSX
 text = unsafeCoerce
+
+-- | `flushSync` lets you force React to flush any updates inside the provided
+-- | callback synchronously. This ensures that the DOM is updated immediately.
+-- | 
+-- | ```purs
+-- | let
+-- |   handleNewChatMessage msg = do
+-- |     flushSync (setMessages (_ <> [msg]))
+-- |     scrollToLastMessage
+-- | ```
+foreign import flushSync :: forall a. Effect a -> Effect a


### PR DESCRIPTION
https://react.dev/reference/react-dom/flushSync

There are numerous disclaimers in the docs
> `flushSync` can significantly hurt performance, and may unexpectedly force pending Suspense boundaries to show their fallback state.
> Most of the time, `flushSync` can be avoided, so use `flushSync` as a last resort.

Could include those here as well. Despite the warnings I've nonetheless found `flushSync` to be useful in a few cases 🙂  like working with the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)  